### PR TITLE
update to TibiaData API v4

### DIFF
--- a/fetch.mjs
+++ b/fetch.mjs
@@ -8,7 +8,7 @@ const getCities = async () => {
 };
 
 const getBuildingsForCity = async (city) => {
-	const response = await fetch(`https://api.tibiadata.com/v3/houses/Antica/${encodeURIComponent(city)}`);
+	const response = await fetch(`https://api.tibiadata.com/v4/houses/Antica/${encodeURIComponent(city)}`);
 	const data = await response.json();
 	console.log(`Processing houses & guildhalls in ${city}…`);
 	return data;


### PR DESCRIPTION
TibiaData API v3 is deprecated and will be removed soon.

Link:
https://tibiadata.com/2024/01/tibiadata-api-v3-has-been-deprecated/